### PR TITLE
Add KMP Compose starter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# KMPlayground
+
+This is a Kotlin Multiplatform (KMP) template configured for Compose Multiplatform.
+The project targets Android, iOS, Web (JS), Desktop, and Server JVM.
+
+## Build
+
+Use the Gradle wrapper to build or run tasks, for example:
+
+```bash
+./gradlew build
+```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,49 @@
 # KMPlayground
 
-This project is a Kotlin Multiplatform (KMP) Compose template.
-It uses **Kotlin 2.0** and **Compose Multiplatform 1.6.10** to target
-Android, iOS, Web (JS), Desktop, and a JVM server.
+This project is a Kotlin Multiplatform (KMP) template showcasing Compose Multiplatform across a number of targets.
+It currently uses **Kotlin 2.0** and **Compose Multiplatform 1.6.10** and builds for:
 
-## Build
+- Android
+- iOS
+- Desktop (JVM)
+- Web (JS)
+- Server (JVM)
 
-Use the Gradle wrapper to build or run tasks, for example:
+## Project layout
+
+```
+build.gradle.kts      // build configuration
+settings.gradle.kts   // project settings
+src/
+  commonMain/         // shared UI and logic
+  commonTest/         // shared tests
+  androidMain/        // Android Activity
+  iosMain/            // iOS UIViewController
+  desktopMain/        // desktop application entry point
+  jsMain/             // web entry point
+  serverMain/         // simple JVM server
+```
+
+## Building
+
+Use Gradle to run tasks for each platform. A few useful examples:
 
 ```bash
-./gradlew build
+# build everything
+gradle build
+
+# run the desktop app
+gradle desktopRun
+
+# start the server
+gradle serverRun
 ```
+
+For Android or iOS you will need the respective SDKs installed. Web can be served with `gradle jsBrowserDevelopmentRun`.
+
+In environments without cached dependencies, Gradle may fail to resolve plugins due to network restrictions.
+
+## Sample feature
+
+The shared `App` composable demonstrates a simple counter using `CounterState` from `commonMain`.
+This logic and UI are reused by all targets to highlight the benefits of KMP.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # KMPlayground
 
-This is a Kotlin Multiplatform (KMP) template configured for Compose Multiplatform.
-The project targets Android, iOS, Web (JS), Desktop, and Server JVM.
+This project is a Kotlin Multiplatform (KMP) Compose template.
+It uses **Kotlin 2.0** and **Compose Multiplatform 1.6.10** to target
+Android, iOS, Web (JS), Desktop, and a JVM server.
 
 ## Build
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,76 @@
+plugins {
+    kotlin("multiplatform") version "1.9.22"
+    id("com.android.application") version "8.2.0"
+    id("org.jetbrains.compose") version "1.6.0"
+}
+
+group = "com.example"
+version = "1.0"
+
+repositories {
+    google()
+    mavenCentral()
+    maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
+}
+
+kotlin {
+    android()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    jvm("desktop")
+    jvm("server")
+    js(IR) {
+        browser {
+            binaries.executable()
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material3)
+            }
+        }
+        val androidMain by getting {
+            dependencies {
+                implementation("androidx.activity:activity-compose:1.8.1")
+            }
+        }
+        val iosMain by creating {
+            dependsOn(commonMain)
+        }
+        val iosX64Main by getting { dependsOn(iosMain) }
+        val iosArm64Main by getting { dependsOn(iosMain) }
+        val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+        val desktopMain by getting {
+            dependencies {
+                implementation(compose.preview)
+            }
+        }
+        val serverMain by getting
+        val jsMain by getting {
+            dependencies {
+                implementation(compose.web.core)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "com.example.composeapp"
+    compileSdk = 34
+    defaultConfig {
+        applicationId = "com.example.composeapp"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,11 @@ kotlin {
                 implementation(compose.material3)
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
         val androidMain by getting {
             dependencies {
                 implementation("androidx.activity:activity-compose:1.9.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("multiplatform") version "1.9.22"
-    id("com.android.application") version "8.2.0"
-    id("org.jetbrains.compose") version "1.6.0"
+    kotlin("multiplatform") version "2.0.0"
+    id("com.android.application") version "8.3.0"
+    id("org.jetbrains.compose") version "1.6.10"
 }
 
 group = "com.example"
@@ -14,6 +14,7 @@ repositories {
 }
 
 kotlin {
+    jvmToolchain(17)
     android()
     iosX64()
     iosArm64()
@@ -36,7 +37,7 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                implementation("androidx.activity:activity-compose:1.8.1")
+                implementation("androidx.activity:activity-compose:1.9.0")
             }
         }
         val iosMain by creating {
@@ -70,7 +71,7 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "KMPlayground"

--- a/src/androidMain/AndroidManifest.xml
+++ b/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest package="com.example.composeapp">
+    <application>
+        <activity android:name="com.example.composeapp.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/androidMain/kotlin/com/example/composeapp/MainActivity.kt
+++ b/src/androidMain/kotlin/com/example/composeapp/MainActivity.kt
@@ -1,0 +1,12 @@
+package com.example.composeapp
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { App() }
+    }
+}

--- a/src/commonMain/kotlin/App.kt
+++ b/src/commonMain/kotlin/App.kt
@@ -1,9 +1,24 @@
 package com.example.composeapp
 
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun App() {
-    Text("Hello, Compose Multiplatform!")
+    val state = remember { CounterState() }
+    Column(
+        modifier = Modifier.padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Count: ${'$'}{state.count}")
+        Button(onClick = { state.increment() }) {
+            Text("Increment")
+        }
+    }
 }

--- a/src/commonMain/kotlin/App.kt
+++ b/src/commonMain/kotlin/App.kt
@@ -1,0 +1,9 @@
+package com.example.composeapp
+
+import androidx.compose.runtime.Composable
+import androidx.compose.material3.Text
+
+@Composable
+fun App() {
+    Text("Hello, Compose Multiplatform!")
+}

--- a/src/commonMain/kotlin/CounterState.kt
+++ b/src/commonMain/kotlin/CounterState.kt
@@ -1,0 +1,10 @@
+package com.example.composeapp
+
+class CounterState {
+    private var _count: Int = 0
+    val count: Int get() = _count
+
+    fun increment() {
+        _count++
+    }
+}

--- a/src/commonTest/kotlin/CounterStateTest.kt
+++ b/src/commonTest/kotlin/CounterStateTest.kt
@@ -1,0 +1,13 @@
+package com.example.composeapp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CounterStateTest {
+    @Test
+    fun counterIncrements() {
+        val state = CounterState()
+        state.increment()
+        assertEquals(1, state.count)
+    }
+}

--- a/src/desktopMain/kotlin/Main.kt
+++ b/src/desktopMain/kotlin/Main.kt
@@ -1,0 +1,8 @@
+package com.example.composeapp
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+
+fun main() = application {
+    Window(onCloseRequest = ::exitApplication) { App() }
+}

--- a/src/iosMain/kotlin/MainViewController.kt
+++ b/src/iosMain/kotlin/MainViewController.kt
@@ -1,0 +1,5 @@
+package com.example.composeapp
+
+import androidx.compose.ui.window.ComposeUIViewController
+
+fun MainViewController() = ComposeUIViewController { App() }

--- a/src/jsMain/kotlin/main.kt
+++ b/src/jsMain/kotlin/main.kt
@@ -1,0 +1,6 @@
+import com.example.composeapp.App
+import org.jetbrains.compose.web.renderComposable
+
+fun main() {
+    renderComposable(rootElementId = "root") { App() }
+}

--- a/src/serverMain/kotlin/Main.kt
+++ b/src/serverMain/kotlin/Main.kt
@@ -1,0 +1,5 @@
+package com.example.composeapp
+
+fun main() {
+    println("Server placeholder")
+}


### PR DESCRIPTION
## Summary
- add a build file configured for Compose Multiplatform and multiple targets
- add platform source sets for Android, iOS, desktop, web and server
- include a very simple `App` composable and entry points
- document how to run the build

## Testing
- `gradle tasks --dry-run` *(fails: Plugin resolution requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68679e01901083329f1ff191b8ca7f44